### PR TITLE
Refactor engine brain

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,17 @@ Also, this is a PET project to better learn Java, Gradle, Spring Boot and the en
 So consider this is the final objective for this project.
 
 These are the features I would like to build next:
-- ~~Game menu~~
-- ~~Players name assignment~~
-- ~~Handle draw game~~
-- ~~Single player match~~
-- Improved validation
-- Refactor using SpringBoot
-- Refactor using DDD/CQRS
-- Engine automated tests
-- UI layer functional tests
-- Single player match: different levels
-- Translations improvements and support for other languages
-- Refactor computeWinner method to handle boards with dynamic sizes
-- Larger board (4x4, 5x5, etc)
-- Web API
-- Choose which player you want to be when playing in single player mode
+1. ~~Game menu~~
+2. ~~Players name assignment~~
+3. ~~Handle draw game~~
+4. ~~Single player match~~
+5. Refactor computeWinner and computerMark
+6. Refactor using SpringBoot
+7. Engine automated tests 
+8. UI layer functional tests 
+9. Web API
+10. Handle multiple matches in parallel
+11. Single player match: different levels 
+12. Translations improvements 
+13. Larger board (4x4, 5x5, etc)
+14. Refactor using DDD/CQRS

--- a/app/src/main/java/com/conizzoli/tictactoe/engine/model/Board.java
+++ b/app/src/main/java/com/conizzoli/tictactoe/engine/model/Board.java
@@ -55,6 +55,10 @@ class Board {
   }
 
   boolean computeIsDraw() {
+    if (this.computeWinner().isPresent()) {
+      return false;
+    }
+    
     for (Player[] row : this.state) {
       for (Player cell : row) {
         if (cell == null) {

--- a/app/src/main/java/com/conizzoli/tictactoe/engine/model/Board.java
+++ b/app/src/main/java/com/conizzoli/tictactoe/engine/model/Board.java
@@ -1,10 +1,19 @@
 package com.conizzoli.tictactoe.engine.model;
 
 import com.conizzoli.tictactoe.engine.exception.BoardLocationAlreadyMarkedException;
+import java.util.Arrays;
 import java.util.Optional;
 
-class Board {
-  private final Player[][] state = new Player[3][3];
+class Board implements Cloneable {
+  private final Player[][] state;
+
+  Board() {
+     this(new Player[3][3]);
+  }
+
+  private Board(Player[][] state) {
+    this.state = state;
+  }
 
   void mark(Player value, BoardLocation boardLocation) throws BoardLocationAlreadyMarkedException {
     var boardLocationPlayer = this.state[boardLocation.column()][boardLocation.row()];
@@ -13,6 +22,14 @@ class Board {
     }
 
     this.state[boardLocation.column()][boardLocation.row()] = value;
+  }
+
+  void nonBlockingMark(Player player, BoardLocation boardLocation) {
+    try {
+      this.mark(player, boardLocation);
+    } catch (BoardLocationAlreadyMarkedException exception) {
+      throw new RuntimeException(exception);
+    }
   }
 
   void removeMark(BoardLocation boardLocation) {
@@ -68,5 +85,14 @@ class Board {
     }
 
     return true;
+  }
+
+  @Override
+  protected Board clone() {
+    var stateClone = Arrays.stream(this.state)
+      .map(Player[]::clone)
+      .toArray(Player[][]::new);
+
+    return new Board(stateClone);
   }
 }

--- a/app/src/main/java/com/conizzoli/tictactoe/engine/model/Board.java
+++ b/app/src/main/java/com/conizzoli/tictactoe/engine/model/Board.java
@@ -29,49 +29,26 @@ class Board {
 
   Optional<Player> computeWinner() {
     // Winner by row
-    outerLoop:
     for (Player[] row : this.state) {
-      if (row[0] == null) {
-        continue;
+      if (row[0] != null && row[0] == row[1] && row[1] == row[2]) {
+        return Optional.of(row[0]);
       }
-
-      var potentialWinner = row[0];
-      for (Player cell : row) {
-        if (cell != potentialWinner) {
-          continue outerLoop;
-        }
-      }
-
-      return Optional.of(potentialWinner);
     }
 
     // Winner by column
-    outerLoop:
     for (var i = 0; i < 3; i++) {
-      if (this.state[0][i] == null) {
-        continue;
+      if (this.state[0][i] != null && this.state[0][i] == this.state[1][i] && this.state[1][i] == this.state[2][i]) {
+        return Optional.of(this.state[0][i]);
       }
-      var potentialWinner = this.state[0][i];
-
-      for (var j = 0; j < 3; j++) {
-        if (this.state[j][i] != potentialWinner) {
-          continue outerLoop;
-        }
-      }
-
-      return Optional.of(potentialWinner);
     }
 
     // Winner by diagonal
-    var potentialWinner = this.state[1][1];
-    if (potentialWinner != null) {
-      if (this.state[0][0] == potentialWinner && this.state[2][2] == potentialWinner) {
-        return Optional.of(potentialWinner);
-      }
+    if (this.state[1][1] != null && this.state[0][0] == this.state[1][1] && this.state[1][1] == this.state[2][2]) {
+      return Optional.of(this.state[1][1]);
 
-      if (this.state[2][0] == potentialWinner && this.state[0][2] == potentialWinner) {
-        return Optional.of(potentialWinner);
-      }
+    }
+    if (this.state[1][1] != null && this.state[2][0] == this.state[1][1] && this.state[1][1] == this.state[0][2]) {
+      return Optional.of(this.state[1][1]);
     }
 
     return Optional.empty();

--- a/app/src/main/java/com/conizzoli/tictactoe/engine/model/Move.java
+++ b/app/src/main/java/com/conizzoli/tictactoe/engine/model/Move.java
@@ -1,6 +1,10 @@
 package com.conizzoli.tictactoe.engine.model;
 
 record Move(int value, int row, int column) implements Comparable<Move> {
+  public Move(int value, BoardLocation boardLocation) {
+    this(value, boardLocation.row(), boardLocation.column());
+  }
+
   @Override
   public int compareTo(Move compareMove) {
     return compareMove.value - value;

--- a/app/src/test/java/com/conizzoli/tictactoe/engine/model/BoardTest.java
+++ b/app/src/test/java/com/conizzoli/tictactoe/engine/model/BoardTest.java
@@ -8,10 +8,10 @@ import org.junit.jupiter.api.Test;
 
 public class BoardTest {
     @Test
-    void itComputesDraw() throws BoardLocationAlreadyMarkedException {
+    void itComputesNotDrawIfFullWithWinner() throws BoardLocationAlreadyMarkedException {
         var board = new Board();
         assertFalse(board.computeIsDraw());
-        
+
         board.mark(Player.CROSS, new BoardLocation(0, 0));
         board.mark(Player.CROSS, new BoardLocation(0, 1));
         board.mark(Player.CROSS, new BoardLocation(1, 0));
@@ -22,6 +22,25 @@ public class BoardTest {
         board.mark(Player.CIRCLE, new BoardLocation(1, 1));
         board.mark(Player.CIRCLE, new BoardLocation(1, 2));
         board.mark(Player.CIRCLE, new BoardLocation(2, 2));
+
+        assertFalse(board.computeIsDraw());
+    }
+
+    @Test
+    void itComputesDrawIfFullWithoutWinner() throws BoardLocationAlreadyMarkedException {
+        var board = new Board();
+        assertFalse(board.computeIsDraw());
+
+        board.mark(Player.CROSS, new BoardLocation(0, 1));
+        board.mark(Player.CROSS, new BoardLocation(0, 2));
+        board.mark(Player.CROSS, new BoardLocation(1, 0));
+        board.mark(Player.CROSS, new BoardLocation(2, 1));
+        board.mark(Player.CROSS, new BoardLocation(2, 2));
+
+        board.mark(Player.CIRCLE, new BoardLocation(0, 0));
+        board.mark(Player.CIRCLE, new BoardLocation(1, 1));
+        board.mark(Player.CIRCLE, new BoardLocation(1, 2));
+        board.mark(Player.CIRCLE, new BoardLocation(2, 0));
 
         assertTrue(board.computeIsDraw());
     }

--- a/app/src/test/java/com/conizzoli/tictactoe/engine/model/BoardTest.java
+++ b/app/src/test/java/com/conizzoli/tictactoe/engine/model/BoardTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.conizzoli.tictactoe.engine.exception.BoardLocationAlreadyMarkedException;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.provider.ValueSource;
 
 public class BoardTest {
     @Test
@@ -28,7 +27,6 @@ public class BoardTest {
     }
 
     @Test
-    @ValueSource(ints = {1, 3, 5, -3, 15, Integer.MAX_VALUE}) // six numbers
     void itComputesRowWin() throws BoardLocationAlreadyMarkedException {
         var board = new Board();
         assertEquals(Optional.empty(), board.computeWinner());


### PR DESCRIPTION
I noticed that, currently, the `computerMark` method is slower when being run in parallel instead of in serial. 
The loop needs about 2-5 seconds in serial mode and always more than 5 to perform the same actions in the stream using multiple threads.